### PR TITLE
Updated package.json for Node.js compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-input-autosize",
   "version": "0.2.2",
   "description": "Auto-resizing Input Component for React",
-  "main": "dist/react-input-autosize.js",
+  "main": "src/AutosizeInput.js",
   "author": "Jed Watson",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The dist file specified as the main entry point did not work in Node.js. Changed to reference the src file, similar to the browser entry point. 
