### PR TITLE
Avoid width problem when using `box-sizing: border-box;`

### DIFF
--- a/lib/AutosizeInput.js
+++ b/lib/AutosizeInput.js
@@ -85,6 +85,7 @@ var AutosizeInput = React.createClass({
 		wrapperStyle.display = 'inline-block';
 		var inputStyle = this.props.inputStyle || {};
 		inputStyle.width = this.state.inputWidth;
+		inputStyle.boxSizing = 'content-box';
 		var placeholder = this.props.placeholder ? React.createElement(
 			'div',
 			{ ref: 'placeholderSizer', style: sizerStyle },

--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -81,6 +81,7 @@ var AutosizeInput = React.createClass({
 		wrapperStyle.display = 'inline-block';
 		var inputStyle = this.props.inputStyle || {};
 		inputStyle.width = this.state.inputWidth;
+		inputStyle.boxSizing = 'content-box';
 		var placeholder = this.props.placeholder ? <div ref="placeholderSizer" style={sizerStyle}>{this.props.placeholder}</div> : null;
 		return (
 			<div className={this.props.className} style={wrapperStyle}>


### PR DESCRIPTION
#7 

You can reproduce it by adding the following css to `example.less`.

``` css
* {
  box-sizing: border-box;
}
```

## Before
[![Gyazo](https://bot.gyazo.com/9c603be35fd75d2534d86cdf18b79f68.png)](https://gyazo.com/9c603be35fd75d2534d86cdf18b79f68)

## After
[![Gyazo](https://bot.gyazo.com/c06f6a25af4e72b66672fdd834916fd4.png)](https://gyazo.com/c06f6a25af4e72b66672fdd834916fd4)