### PR TITLE
Update for React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "eslint-plugin-react": "^2.7.0",
     "gulp": "^3.9.0",
     "jest-cli": "^0.4.15",
-    "react": ">=0.13.0 || ^0.14.0-alpha",
+    "react": ">=0.14.0",
     "react-component-gulp-tasks": "^0.7.0"
   },
   "peerDependencies": {
-    "react": ">=0.13.0 || ^0.14.0-alpha"
+    "react": ">=0.14.0"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -37,27 +37,27 @@ var AutosizeInput = React.createClass({
 		if (!this.isMounted() || !window.getComputedStyle) {
 			return;
 		}
-		var inputStyle = window.getComputedStyle(React.findDOMNode(this.refs.input));
-		var widthNode = React.findDOMNode(this.refs.sizer);
+		var inputStyle = window.getComputedStyle(this.refs.input);
+		var widthNode = this.refs.sizer;
 		widthNode.style.fontSize = inputStyle.fontSize;
 		widthNode.style.fontFamily = inputStyle.fontFamily;
 		widthNode.style.letterSpacing = inputStyle.letterSpacing;
 		if (this.props.placeholder) {
-			var placeholderNode = React.findDOMNode(this.refs.placeholderSizer);
+			var placeholderNode = this.refs.placeholderSizer;
 			placeholderNode.style.fontSize = inputStyle.fontSize;
 			placeholderNode.style.fontFamily = inputStyle.fontFamily;
 			placeholderNode.style.letterSpacing = inputStyle.letterSpacing;
 		}
 	},
 	updateInputWidth () {
-		if (!this.isMounted() || typeof React.findDOMNode(this.refs.sizer).scrollWidth === 'undefined') {
+		if (!this.isMounted() || typeof this.refs.sizer.scrollWidth === 'undefined') {
 			return;
 		}
 		var newInputWidth;
 		if (this.props.placeholder) {
-			newInputWidth = Math.max(React.findDOMNode(this.refs.sizer).scrollWidth, React.findDOMNode(this.refs.placeholderSizer).scrollWidth) + 2;
+			newInputWidth = Math.max(this.refs.sizer.scrollWidth, this.refs.placeholderSizer.scrollWidth) + 2;
 		} else {
-			newInputWidth = React.findDOMNode(this.refs.sizer).scrollWidth + 2;
+			newInputWidth = this.refs.sizer.scrollWidth + 2;
 		}
 		if (newInputWidth < this.props.minWidth) {
 			newInputWidth = this.props.minWidth;
@@ -72,10 +72,10 @@ var AutosizeInput = React.createClass({
 		return this.refs.input;
 	},
 	focus () {
-		React.findDOMNode(this.refs.input).focus();
+		this.refs.input.focus();
 	},
 	select () {
-		React.findDOMNode(this.refs.input).select();
+		this.refs.input.select();
 	},
 	render () {
 		var escapedValue = (this.props.value || '').replace(/\&/g, '&amp;').replace(/ /g, '&nbsp;').replace(/\</g, '&lt;').replace(/\>/g, '&gt;');


### PR DESCRIPTION
- Directly depend on react@>=0.14.0
- Drop use of React.findDOMNode on refs which is no longer necessary
  - This also drops the need to peer depend on react-dom to use ReactDOM.findDOMNode

Ideally I would add react-dom to devDependencies and use it in example/src/app.js to eliminate the React warning.

However react-component-gulp-tasks does not account for devDeps and the examples break when doing that.