### PR TITLE
Drop usage of ReactDOM.findDOMNode which is no longer necessary on refs.

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -1,5 +1,4 @@
 var React = require('react');
-var ReactDOM = require('react-dom');
 
 var sizerStyle = { position: 'absolute', visibility: 'hidden', height: 0, width: 0, overflow: 'scroll', whiteSpace: 'nowrap' };
 
@@ -38,27 +37,27 @@ var AutosizeInput = React.createClass({
 		if (!this.isMounted() || !window.getComputedStyle) {
 			return;
 		}
-		var inputStyle = window.getComputedStyle(ReactDOM.findDOMNode(this.refs.input));
-		var widthNode = ReactDOM.findDOMNode(this.refs.sizer);
+		var inputStyle = window.getComputedStyle(this.refs.input);
+		var widthNode = this.refs.sizer;
 		widthNode.style.fontSize = inputStyle.fontSize;
 		widthNode.style.fontFamily = inputStyle.fontFamily;
 		widthNode.style.letterSpacing = inputStyle.letterSpacing;
 		if (this.props.placeholder) {
-			var placeholderNode = ReactDOM.findDOMNode(this.refs.placeholderSizer);
+			var placeholderNode = this.refs.placeholderSizer;
 			placeholderNode.style.fontSize = inputStyle.fontSize;
 			placeholderNode.style.fontFamily = inputStyle.fontFamily;
 			placeholderNode.style.letterSpacing = inputStyle.letterSpacing;
 		}
 	},
 	updateInputWidth () {
-		if (!this.isMounted() || typeof ReactDOM.findDOMNode(this.refs.sizer).scrollWidth === 'undefined') {
+		if (!this.isMounted() || typeof this.refs.sizer.scrollWidth === 'undefined') {
 			return;
 		}
 		var newInputWidth;
 		if (this.props.placeholder) {
-			newInputWidth = Math.max(ReactDOM.findDOMNode(this.refs.sizer).scrollWidth, ReactDOM.findDOMNode(this.refs.placeholderSizer).scrollWidth) + 2;
+			newInputWidth = Math.max(this.refs.sizer.scrollWidth, this.refs.placeholderSizer.scrollWidth) + 2;
 		} else {
-			newInputWidth = ReactDOM.findDOMNode(this.refs.sizer).scrollWidth + 2;
+			newInputWidth = this.refs.sizer.scrollWidth + 2;
 		}
 		if (newInputWidth < this.props.minWidth) {
 			newInputWidth = this.props.minWidth;
@@ -73,10 +72,10 @@ var AutosizeInput = React.createClass({
 		return this.refs.input;
 	},
 	focus () {
-		ReactDOM.findDOMNode(this.refs.input).focus();
+		this.refs.input.focus();
 	},
 	select () {
-		ReactDOM.findDOMNode(this.refs.input).select();
+		this.refs.input.select();
 	},
 	render () {
 		var escapedValue = (this.props.value || '').replace(/\&/g, '&amp;').replace(/ /g, '&nbsp;').replace(/\</g, '&lt;').replace(/\>/g, '&gt;');


### PR DESCRIPTION
`react-dom` is no longer required in peerDependencies, however it can't be dropped until JedWatson/react-component-gulp-tasks#14 is fixed.