### PR TITLE
Add 'px' to style inputStyle.width

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -101,7 +101,7 @@ const AutosizeInput = React.createClass({
 		const wrapperStyle = this.props.style || {};
 		if (!wrapperStyle.display) wrapperStyle.display = 'inline-block';
 		const inputStyle = Object.assign({}, this.props.inputStyle);
-		inputStyle.width = this.state.inputWidth;
+		inputStyle.width = this.state.inputWidth + 'px';
 		inputStyle.boxSizing = 'content-box';
 		const placeholder = this.props.placeholder ? <div ref="placeholderSizer" style={sizerStyle}>{this.props.placeholder}</div> : null;
 		return (


### PR DESCRIPTION
Solve this warning in React v15.0:

```
Warning: a `input` tag (owner: `AutosizeInput`) was passed a numeric string value for CSS property `width` (value: `5`) which will be treated as a unitless number in a future version of React.
```