### PR TITLE
Chrome - Maximum call stack size exceeded

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -1,6 +1,6 @@
 const React = require('react');
 
-const sizerStyle = { position: 'absolute', visibility: 'hidden', height: 0, width: 0, overflow: 'scroll', whiteSpace: 'pre' };
+const sizerStyle = { position: 'absolute', top: 0, left: 0, visibility: 'hidden', height: 0, width: 0, overflow: 'scroll', whiteSpace: 'pre' };
 
 const nextFrame = typeof window !== 'undefined' ? (function(){
 	return window.requestAnimationFrame


### PR DESCRIPTION
On latest chrome the following result in a `RangeError: Maximum call stack size exceeded`

```jsx
<div style={{position: 'relative'}}>
  <div style={{textAlign: 'center'}}>
    <AutosizeInput value={12} inputStyle={{ fontSize: 14 }} />
  </div>
</div>
```

Something more complicated with `onChange` & `value` props will also cause this issue. Setting the placement of the absolute positioned sizer fixes it, otherwise chrome keep returning 1px difference on the sizer scrollWidth for some obscure reason that I do not know, causing infinite re-renders.