### PR TITLE
Removes minWidth from props passed to input element. Fixes #53

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -97,9 +97,10 @@ const AutosizeInput = React.createClass({
 		inputStyle.width = this.state.inputWidth + 'px';
 		inputStyle.boxSizing = 'content-box';
 		const placeholder = this.props.placeholder ? <div ref="placeholderSizer" style={sizerStyle}>{this.props.placeholder}</div> : null;
+		const {minWidth, ...domProps} = this.props;
 		return (
 			<div className={this.props.className} style={wrapperStyle}>
-				<input {...this.props} ref="input" className={this.props.inputClassName} style={inputStyle} />
+				<input {...domProps} ref="input" className={this.props.inputClassName} style={inputStyle} />
 				<div ref="sizer" style={sizerStyle}>{sizerValue}</div>
 				{placeholder}
 			</div>


### PR DESCRIPTION
Removes minWidth from props passed to input element, this was causing React 15.2.x to throw a warning. minWidth is not a valid DOM property. Fixes https://github.com/JedWatson/react-input-autosize/issues/53
