### PR TITLE
Add onAutosize callback to respond to width changes

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -12,6 +12,7 @@ const AutosizeInput = React.createClass({
 			React.PropTypes.number,
 			React.PropTypes.string,
 		]),
+		onAutosize: React.PropTypes.func,                // onAutosize handler: function(newWidth) {}
 		onChange: React.PropTypes.func,                  // onChange handler: function(newValue) {}
 		placeholder: React.PropTypes.string,             // placeholder text
 		placeholderIsMinWidth: React.PropTypes.bool,     // don't collapse size to less than the placeholder
@@ -32,7 +33,12 @@ const AutosizeInput = React.createClass({
 		this.copyInputStyles();
 		this.updateInputWidth();
 	},
-	componentDidUpdate () {
+	componentDidUpdate (prevProps, prevState) {
+		if (prevState.inputWidth !== this.state.inputWidth) {
+			if (typeof this.props.onAutosize === 'function') {
+				this.props.onAutosize(this.state.inputWidth);
+			}
+		}
 		this.updateInputWidth();
 	},
 	copyInputStyles () {


### PR DESCRIPTION
This PR adds a callback that's invoked after the component flushes a width change to the DOM. The use case here is that I have a `position: fixed` element whose position is determined by the position/dimensions of the `<AutosizeInput>`. Repositioning the fixed element in response to `onChange` or in response to the parent component's `componentDidUpdate` doesn't work, because those functions are called before the `<AutosizeInput>` width changes flush to the DOM.