### PR TITLE
Fix text transform bug

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -55,6 +55,7 @@ const AutosizeInput = React.createClass({
 		widthNode.style.fontWeight = inputStyle.fontWeight;
 		widthNode.style.fontStyle = inputStyle.fontStyle;
 		widthNode.style.letterSpacing = inputStyle.letterSpacing;
+		widthNode.style.textTransform = inputStyle.textTransform;
 		if (this.props.placeholder) {
 			const placeholderNode = this.refs.placeholderSizer;
 			placeholderNode.style.fontSize = inputStyle.fontSize;
@@ -62,6 +63,7 @@ const AutosizeInput = React.createClass({
 			placeholderNode.style.fontWeight = inputStyle.fontWeight;
 			placeholderNode.style.fontStyle = inputStyle.fontStyle;
 			placeholderNode.style.letterSpacing = inputStyle.letterSpacing;
+			placeholderNode.style.textTransform = inputStyle.textTransform;
 		}
 	},
 	updateInputWidth () {


### PR DESCRIPTION
When i.g. when using the CSS property `text-transform: uppercase` the font is way larger and the input doesn't get updated in size properly. This PR fixes that, already test it in a own project.
