### PR TITLE
Don't pass onAutosize through to <input />

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -116,6 +116,7 @@ const AutosizeInput = React.createClass({
 		delete inputProps.inputClassName;
 		delete inputProps.inputStyle;
 		delete inputProps.minWidth;
+		delete inputProps.onAutosize;
 		delete inputProps.placeholderIsMinWidth;
 		return (
 			<div className={this.props.className} style={wrapperStyle}>


### PR DESCRIPTION
@JedWatson A small addendum to #64. Currently the `onAutosize` handler is being passed through to the `<input />`, triggering a warning in React 0.15+.
