### PR TITLE
Use callback refs as per react recommendations.  Don't inspect elemen…

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -19,16 +19,14 @@ const AutosizeInput = React.createClass({
 		style: React.PropTypes.object,                   // css styles for the outer element
 		value: React.PropTypes.any,                      // field value
 	},
-	refHandlers: {
-		input: function(el) {
-			this.input = el;
-		},
-		placeHolderSizer: function(el) {
-			this.placeHolderSizer = el;
-		},
-		sizer: function(el) {
-			this.sizer = el;
-		},
+	inputRef: function(el) {
+		this.input = el;
+	},
+	placeHolderSizerRef: function(el) {
+		this.placeHolderSizer = el;
+	},
+	sizerRef: function(el) {
+		this.sizer = el;
 	},
 	getDefaultProps () {
 		return {
@@ -130,9 +128,9 @@ const AutosizeInput = React.createClass({
 		delete inputProps.placeholderIsMinWidth;
 		return (
 			<div className={this.props.className} style={wrapperStyle}>
-				<input {...inputProps} ref={ this.refHandlers.input.bind(this) } />
-				<div ref={ this.refHandlers.sizer.bind(this) } style={sizerStyle}>{sizerValue}</div>
-				{this.props.placeholder ? <div ref={ this.refHandlers.placeholderSizer.bind(this) } style={sizerStyle}>{this.props.placeholder}</div> : null}
+				<input {...inputProps} ref={ this.inputRef } />
+				<div ref={ this.sizerRef } style={sizerStyle}>{sizerValue}</div>
+				{this.props.placeholder ? <div ref={ this.placeHolderSizerRef } style={sizerStyle}>{this.props.placeholder}</div> : null}
 			</div>
 		);
 	},

--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -19,6 +19,17 @@ const AutosizeInput = React.createClass({
 		style: React.PropTypes.object,                   // css styles for the outer element
 		value: React.PropTypes.any,                      // field value
 	},
+	refHandlers: {
+		input: function(el) {
+			this.input = el;
+		},
+		placeHolderSizer: function(el) {
+			this.placeHolderSizer = el;
+		},
+		sizer: function(el) {
+			this.sizer = el;
+		},
+	},
 	getDefaultProps () {
 		return {
 			minWidth: 1,
@@ -45,18 +56,18 @@ const AutosizeInput = React.createClass({
 		if (!this.isMounted() || !window.getComputedStyle) {
 			return;
 		}
-		const inputStyle = window.getComputedStyle(this.refs.input);
+		const inputStyle = this.input && window.getComputedStyle(this.input);
 		if (!inputStyle) {
 			return;
 		}
-		const widthNode = this.refs.sizer;
+		const widthNode = this.sizer;
 		widthNode.style.fontSize = inputStyle.fontSize;
 		widthNode.style.fontFamily = inputStyle.fontFamily;
 		widthNode.style.fontWeight = inputStyle.fontWeight;
 		widthNode.style.fontStyle = inputStyle.fontStyle;
 		widthNode.style.letterSpacing = inputStyle.letterSpacing;
 		if (this.props.placeholder) {
-			const placeholderNode = this.refs.placeholderSizer;
+			const placeholderNode = this.placeHolderSizer;
 			placeholderNode.style.fontSize = inputStyle.fontSize;
 			placeholderNode.style.fontFamily = inputStyle.fontFamily;
 			placeholderNode.style.fontWeight = inputStyle.fontWeight;
@@ -65,12 +76,12 @@ const AutosizeInput = React.createClass({
 		}
 	},
 	updateInputWidth () {
-		if (!this.isMounted() || typeof this.refs.sizer.scrollWidth === 'undefined') {
+		if (!this.isMounted() || !this.sizer || typeof this.sizer.scrollWidth === 'undefined') {
 			return;
 		}
 		let newInputWidth;
 		if (this.props.placeholder && (!this.props.value || (this.props.value && this.props.placeholderIsMinWidth))) {
-			newInputWidth = Math.max(this.refs.sizer.scrollWidth, this.refs.placeholderSizer.scrollWidth) + 2;
+			newInputWidth = Math.max(this.sizer.scrollWidth, this.placeHolderSizer.scrollWidth) + 2;
 		} else {
 			newInputWidth = this.refs.sizer.scrollWidth + 2;
 		}
@@ -84,16 +95,16 @@ const AutosizeInput = React.createClass({
 		}
 	},
 	getInput () {
-		return this.refs.input;
+		return this.input;
 	},
 	focus () {
-		this.refs.input.focus();
+		this.input.focus();
 	},
 	blur () {
-		this.refs.input.blur();
+		this.input.blur();
 	},
 	select () {
-		this.refs.input.select();
+		this.input.select();
 	},
 	render () {
 		const sizerValue = [this.props.defaultValue, this.props.value, ''].reduce(function (previousValue, currentValue) {
@@ -119,9 +130,9 @@ const AutosizeInput = React.createClass({
 		delete inputProps.placeholderIsMinWidth;
 		return (
 			<div className={this.props.className} style={wrapperStyle}>
-				<input {...inputProps} ref="input" />
-				<div ref="sizer" style={sizerStyle}>{sizerValue}</div>
-				{this.props.placeholder ? <div ref="placeholderSizer" style={sizerStyle}>{this.props.placeholder}</div> : null}
+				<input {...inputProps} ref={ this.refHandlers.input.bind(this) } />
+				<div ref={ this.refHandlers.sizer.bind(this) } style={sizerStyle}>{sizerValue}</div>
+				{this.props.placeholder ? <div ref={ this.refHandlers.placeholderSizer.bind(this) } style={sizerStyle}>{this.props.placeholder}</div> : null}
 			</div>
 		);
 	},


### PR DESCRIPTION
…ts that don't exist.

1. Don't use string refs, as they're deprecated.
2. `this.refs.input` and `this.refs.sizer` were having their style analyzed before they existed which was breaking any rendering of this component in a test environment (jsdom).