### PR TITLE
Switch to prop-types and create-react-class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-input-autosize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Auto-resizing Input Component for React",
   "main": "lib/AutosizeInput.js",
   "author": "Jed Watson",
@@ -11,11 +11,13 @@
   },
   "devDependencies": {
     "babel-jest": "^6.0.1",
+    "create-react-class": "15.5.1",
     "eslint": "^2.11.1",
     "eslint-config-keystone": "^2.2.0",
     "eslint-plugin-react": "^5.1.1",
     "gulp": "^3.9.0",
     "jest-cli": "^0.8.1",
+    "prop-types": "15.5.6"
     "react": "^15.0",
     "react-addons-test-utils": "^15.0",
     "react-component-gulp-tasks": "^0.7.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-react": "^5.1.1",
     "gulp": "^3.9.0",
     "jest-cli": "^0.8.1",
-    "prop-types": "15.5.6"
+    "prop-types": "15.5.6",
     "react": "^15.0",
     "react-addons-test-utils": "^15.0",
     "react-component-gulp-tasks": "^0.7.6",

--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -1,23 +1,25 @@
 const React = require('react');
+const PropTypes = require('prop-types');
+const createClass = require('create-react-class');
 
 const sizerStyle = { position: 'absolute', top: 0, left: 0, visibility: 'hidden', height: 0, overflow: 'scroll', whiteSpace: 'pre' };
 
-const AutosizeInput = React.createClass({
+const AutosizeInput = createClass({
 	propTypes: {
-		className: React.PropTypes.string,               // className for the outer element
-		defaultValue: React.PropTypes.any,               // default field value
-		inputClassName: React.PropTypes.string,          // className for the input element
-		inputStyle: React.PropTypes.object,              // css styles for the input element
-		minWidth: React.PropTypes.oneOfType([            // minimum width for input element
-			React.PropTypes.number,
-			React.PropTypes.string,
+		className: PropTypes.string,               // className for the outer element
+		defaultValue: PropTypes.any,               // default field value
+		inputClassName: PropTypes.string,          // className for the input element
+		inputStyle: PropTypes.object,              // css styles for the input element
+		minWidth: PropTypes.oneOfType([            // minimum width for input element
+			PropTypes.number,
+			PropTypes.string,
 		]),
-		onAutosize: React.PropTypes.func,                // onAutosize handler: function(newWidth) {}
-		onChange: React.PropTypes.func,                  // onChange handler: function(newValue) {}
-		placeholder: React.PropTypes.string,             // placeholder text
-		placeholderIsMinWidth: React.PropTypes.bool,     // don't collapse size to less than the placeholder
-		style: React.PropTypes.object,                   // css styles for the outer element
-		value: React.PropTypes.any,                      // field value
+		onAutosize: PropTypes.func,                // onAutosize handler: function(newWidth) {}
+		onChange: PropTypes.func,                  // onChange handler: function(newValue) {}
+		placeholder: PropTypes.string,             // placeholder text
+		placeholderIsMinWidth: PropTypes.bool,     // don't collapse size to less than the placeholder
+		style: PropTypes.object,                   // css styles for the outer element
+		value: PropTypes.any,                      // field value
 	},
 	getDefaultProps () {
 		return {


### PR DESCRIPTION
React 15.5 has deprecated `React.createClass` and `React.PropTypes`. This fixes that issue.