### PR TITLE
moving packages to dependencies [fixes #82]

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
   },
   "devDependencies": {
     "babel-jest": "^6.0.1",
-    "create-react-class": "^15.5.2",
     "eslint": "^3.19.0",
     "eslint-config-keystone": "^3.0.0",
     "eslint-config-keystone-react": "^1.0.0",
     "eslint-plugin-react": "^6.10.3",
     "gulp": "^3.9.0",
     "jest-cli": "^0.8.1",
-    "prop-types": "^15.5.8",
     "react": "^15.0",
     "react-addons-test-utils": "^15.0",
     "react-component-gulp-tasks": "^0.7.6",
     "react-dom": "^15.0"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0.0-rc || ^15.0"
+    "create-react-class": "^15.5.2",
+    "react": "^0.14 || ^15.0.0-rc || ^15.0",
+    "prop-types": "^15.5.8"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/JedWatson/react-input-autosize.git"
   },
+  "dependencies": {
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.8"
+  },
   "devDependencies": {
     "babel-jest": "^6.0.1",
     "eslint": "^3.19.0",
@@ -23,9 +27,7 @@
     "react-dom": "^15.0"
   },
   "peerDependencies": {
-    "create-react-class": "^15.5.2",
-    "react": "^0.14 || ^15.0.0-rc || ^15.0",
-    "prop-types": "^15.5.8"
+    "react": "^0.14 || ^15.0.0-rc || ^15.0"
   },
   "browserify-shim": {
     "react": "global:React"


### PR DESCRIPTION
– moving prop-types and create-react-class