### PR TITLE
Move run-time dependencies out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,18 @@
     "type": "git",
     "url": "https://github.com/JedWatson/react-input-autosize.git"
   },
+  "dependencies": {
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.8"
+  },
   "devDependencies": {
     "babel-jest": "^6.0.1",
-    "create-react-class": "^15.5.2",
     "eslint": "^3.19.0",
     "eslint-config-keystone": "^3.0.0",
     "eslint-config-keystone-react": "^1.0.0",
     "eslint-plugin-react": "^6.10.3",
     "gulp": "^3.9.0",
     "jest-cli": "^0.8.1",
-    "prop-types": "^15.5.8",
     "react": "^15.0",
     "react-addons-test-utils": "^15.0",
     "react-component-gulp-tasks": "^0.7.6",


### PR DESCRIPTION
`prop-types` and `create-react-class` are currently listed in `devDependencies`, but are in fact run-time dependencies and as such should be under `dependencies`.