### PR TITLE
Fix copyInputStyles() never running.

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -65,7 +65,7 @@ const AutosizeInput = createClass({
 		this.sizer = el;
 	},
 	copyInputStyles () {
-		if (this.mounted || !window.getComputedStyle) {
+		if (!this.mounted || !window.getComputedStyle) {
 			return;
 		}
 		const inputStyle = this.input && window.getComputedStyle(this.input);


### PR DESCRIPTION
This was broken in 5da2322b840218781fa42d070efbef2473c8c246.