### PR TITLE
Allow for overriding of input inline styles

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -113,9 +113,11 @@ class AutosizeInput extends Component {
 
 		const wrapperStyle = { ...this.props.style };
 		if (!wrapperStyle.display) wrapperStyle.display = 'inline-block';
-		const inputStyle = { ...this.props.inputStyle };
-		inputStyle.width = this.state.inputWidth + 'px';
-		inputStyle.boxSizing = 'content-box';
+		const inputStyle = {
+			boxSizing: 'content-box',
+			width: this.state.inputWidht + 'px',
+			...this.props.inputStyle,
+		};
 		const { ...inputProps } = this.props;
 		inputProps.className = this.props.inputClassName;
 		inputProps.style = inputStyle;


### PR DESCRIPTION
It would be nice if the object passed to prop.inputStyles was spread after setting the width and boxSizing properties. This way if the user does need to set one of these properties to a different value there is a way to do so.

For my use case I needed to set the box-sizing property to border-box. 