### PR TITLE
Set sizer overflow to hidden.

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -7,7 +7,7 @@ const sizerStyle = {
 	left: 0,
 	visibility: 'hidden',
 	height: 0,
-	overflow: 'scroll',
+	overflow: 'hidden',
 	whiteSpace: 'pre',
 };
 


### PR DESCRIPTION
I have been experiencing some odd bugs in different versions of FireFox where the width is being calculate incorrectly when I apply horizontal padding on the underlying input. Although I have seen this issue occur multiple times, it has been very hard to reproduce within my own system, so I am not going to try to reproduce in a generic example.

I have found that setting overflow to hidden fixes the problem,  but still allows the sizer width to be determined via the scrollWidth property. I have provided a Codepen below that demonstrates this behavior.

https://codepen.io/anon/pen/jaeWpN