### PR TITLE
Guard against undefined window and window.document

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -35,7 +35,7 @@ const copyStyles = (styles, node) => {
 	node.style.textTransform = styles.textTransform;
 };
 
-const isIE = (typeof window === 'undefined') ? false : /MSIE |Trident\/|Edge\//.test(window.navigator.userAgent);
+const isIE = (typeof window === 'undefined' && window.document) ? false : /MSIE |Trident\/|Edge\//.test(window.navigator.userAgent);
 
 const generateId = () => {
 	// we only need an auto-generated ID for stylesheet injection, which is only


### PR DESCRIPTION
This should fix https://github.com/JedWatson/react-input-autosize/issues/117

Checking for window still fails since in some cases the SSR defines window, it's safer to additionally check the document.
See https://github.com/JedWatson/react-input-autosize/issues/117#issuecomment-350230244