### PR TITLE
fix window undefined check

### DIFF
--- a/src/AutosizeInput.js
+++ b/src/AutosizeInput.js
@@ -36,7 +36,7 @@ const copyStyles = (styles, node) => {
 	node.style.textTransform = styles.textTransform;
 };
 
-const isIE = (typeof window === 'undefined' && window.document) ? false : /MSIE |Trident\/|Edge\//.test(window.navigator.userAgent);
+const isIE = (typeof window === 'undefined' || typeof window.document === 'undefined') ? false : /MSIE |Trident\/|Edge\//.test(window.navigator.userAgent);
 
 const generateId = () => {
 	// we only need an auto-generated ID for stylesheet injection, which is only


### PR DESCRIPTION
Fixes #123 
If window is undefined, window.document will throw an error
  