### PR TITLE
Upgrade Babel preset es2015 to Babel preset env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["es2015"],
+    ["env"],
     "stage-2",
     "react",
   ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "css-loader": "^0.28.7",


### PR DESCRIPTION
Upgraded Babel preset to env as recommended by Babel
Took [React Select](https://github.com/JedWatson/react-select) files as examples together with instruction from [Babel](http://babeljs.io/env)